### PR TITLE
fix(rest): Properly wrap rest.body decorator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,6 @@ target/
 
 # Ignore .idea/ dir that gets created
 .idea/
+
+# MacOS folder metadata
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # simpl
-[![Build Status](https://travis-ci.org/checkmate/simpl.svg?branch=master)](https://travis-ci.org/checkmate/simpl)
+[![Build Status](https://travis-ci.org/rackerlabs/simpl.svg?branch=master)](https://travis-ci.org/rackerlabs/simpl)
 [![Coverage Status](https://coveralls.io/repos/checkmate/simpl/badge.svg?branch=master)](https://coveralls.io/r/checkmate/simpl?branch=master)
 
 Common Python libraries for:
@@ -82,4 +82,4 @@ that works with the [rest][#rest] module and supports query param filtering
 
 | Branch        | Status  |
 | ------------- | ------------- |
-| [master](https://github.com/checkmate/simpl/tree/master)  | [![Build Status](https://travis-ci.org/checkmate/simpl.svg?branch=master)](https://travis-ci.org/checkmate/simpl)  |
+| [master](https://github.com/rackerlabs/simpl/tree/master)  | [![Build Status](https://travis-ci.org/rackerlabs/simpl.svg?branch=master)](https://travis-ci.org/rackerlabs/simpl)  |

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,1 +1,1 @@
-sphinx
+sphinx==1.3.6

--- a/simpl/config.py
+++ b/simpl/config.py
@@ -577,7 +577,7 @@ class Config(collections.MutableMapping):
         results = {}
         if not namespace:
             namespace = self.prog
-        namespace = namespace.upper()
+        namespace = namespace.upper()  # pylint: disable=no-member
         for option in self._options:
             env_var = option.kwargs.get('env')
             default_env = "%s_%s" % (namespace, option.name.upper())

--- a/simpl/incubator/rest.py
+++ b/simpl/incubator/rest.py
@@ -24,7 +24,6 @@ from simpl import rest as simpl_rest
 
 
 class MultiValidationError(Exception):
-
     """Basically a re-imagining of a `voluptuous.MultipleInvalid` error.
 
     Reformats multiple errors messages for easy debugging of invalid
@@ -32,7 +31,7 @@ class MultiValidationError(Exception):
     """
 
     def __init__(self, errors):
-        """MultiValidationError constructor.
+        """Constructor of MultiValidationError class.
 
         :param errors:
             List of `voluptuous.Invalid` or `voluptuous.MultipleInvalid`

--- a/simpl/rest.py
+++ b/simpl/rest.py
@@ -71,7 +71,7 @@ def body(schema=None, types=None, required=False, default=None):
                 except Exception as exc:
                     bottle.abort(400, str(exc))
             return fxn(data, *args, **kwargs)
-        return wrapped
+        return functools.wraps(fxn)(wrapped)
     return wrap
 
 

--- a/simpl/server.py
+++ b/simpl/server.py
@@ -321,8 +321,8 @@ def fmt_routes(bottle_app):
 def _version_callback():
     """Return a dict of simpl version info."""
     return {
-        'version': simpl.__version__,
-        'url': simpl.__url__,
+        'version': simpl.__version__,  # pylint: disable=no-member
+        'url': simpl.__url__,  # pylint: disable=no-member
     }
 
 

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -8,6 +8,7 @@ mongobox
 nose
 nose-ignore-docstring
 prettyprint
+pycodestyle
 pylint
 pyyaml
 requests

--- a/tests/test_rest.py
+++ b/tests/test_rest.py
@@ -32,6 +32,7 @@ class TestBodyDecorator(unittest.TestCase):
     def test_decoration(self):
         """Test decorated function is called."""
         mock_handler = mock.Mock(return_value='X')
+        mock_handler.__name__ = 'mock_handler'
         decorated = rest.body()(mock_handler)
         self.assertTrue(callable(decorated))
         self.assertEqual(decorated('arg', kwarg=2), 'X')
@@ -43,6 +44,7 @@ class TestBodyDecorator(unittest.TestCase):
         data = "100"
         mock_request.json = data
         mock_handler = mock.Mock()
+        mock_handler.__name__ = 'mock_handler'
         route = rest.body(schema=int)(mock_handler)
         route()
         mock_handler.assert_called_once_with(int(data))
@@ -52,6 +54,7 @@ class TestBodyDecorator(unittest.TestCase):
         """Test schema is enforced."""
         mock_request.json = 'ALPHA'
         mock_handler = mock.Mock()
+        mock_handler.__name__ = 'mock_handler'
         route = rest.body(schema=int)(mock_handler)
         with self.assertRaises(bottle.HTTPError):
             route()
@@ -61,6 +64,7 @@ class TestBodyDecorator(unittest.TestCase):
         """Test invalid data is handled gracefully."""
         type(mock_request).json = mock.PropertyMock(side_effect=ValueError)
         mock_handler = mock.Mock()
+        mock_handler.__name__ = 'mock_handler'
         route = rest.body(schema=int)(mock_handler)
         with self.assertRaises(bottle.HTTPError):
             route()
@@ -71,6 +75,7 @@ class TestBodyDecorator(unittest.TestCase):
         type(mock_request).json = mock.PropertyMock(
             side_effect=UnicodeDecodeError('ascii', b'', 0, 1, 'bad'))
         mock_handler = mock.Mock()
+        mock_handler.__name__ = 'mock_handler'
         route = rest.body(schema=int)(mock_handler)
         with self.assertRaises(bottle.HTTPError):
             route()
@@ -80,6 +85,7 @@ class TestBodyDecorator(unittest.TestCase):
         """Test required is enforced."""
         mock_request.json = None
         mock_handler = mock.Mock()
+        mock_handler.__name__ = 'mock_handler'
         route = rest.body(required=True)(mock_handler)
         with self.assertRaises(bottle.HTTPError) as context:
             route()
@@ -90,6 +96,7 @@ class TestBodyDecorator(unittest.TestCase):
         """Test default is returned (and schema is applied to it)."""
         mock_request.json = None
         mock_handler = mock.Mock()
+        mock_handler.__name__ = 'mock_handler'
         route = rest.body(default='100', schema=int)(mock_handler)
         route()
         mock_handler.assert_called_once_with(100)


### PR DESCRIPTION
Without using `functools.wraps`, the decorator will mask the underlying stack of functions.